### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,31 +2,31 @@
 # DataTypes (KEYWORD1)
 ############
 
-LT8900 KEYWORD1
-DataRate KEYWORD1
+LT8900	KEYWORD1
+DataRate	KEYWORD1
 
 #######################
 # Methods and Functions (KEYWORD2)
 #######################
 
-begin KEYWORD2
-setChannel KEYWORD2
-getChannel KEYWORD2
-setDataRate KEYWORD2
-setCurrentControl KEYWORD2
-getDataRate KEYWORD2
-readRegister KEYWORD2
-writeRegister KEYWORD2
-sleep KEYWORD2
-whatsUp KEYWORD2
-available KEYWORD2
-getIs8910 KEYWORD2
-read KEYWORD2
-startListening KEYWORD2
-setClock KEYWORD2
-sendPacket KEYWORD2
-setSyncWord KEYWORD2
-setSyncWordLength KEYWORD2
+begin	KEYWORD2
+setChannel	KEYWORD2
+getChannel	KEYWORD2
+setDataRate	KEYWORD2
+setCurrentControl	KEYWORD2
+getDataRate	KEYWORD2
+readRegister	KEYWORD2
+writeRegister	KEYWORD2
+sleep	KEYWORD2
+whatsUp	KEYWORD2
+available	KEYWORD2
+getIs8910	KEYWORD2
+read	KEYWORD2
+startListening	KEYWORD2
+setClock	KEYWORD2
+sendPacket	KEYWORD2
+setSyncWord	KEYWORD2
+setSyncWordLength	KEYWORD2
 
 ######################
 # CONSTANTS (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords